### PR TITLE
3.8 compat

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -55,3 +55,6 @@
 .taxonomy-image-control .show {
 	visibility: visible;
 }
+body.taxonomy-images-modal {
+	background: #F1F1F1 !important;
+}

--- a/edit-tags.js
+++ b/edit-tags.js
@@ -20,7 +20,8 @@ jQuery( document ).ready( function( $ ) {
 			success: function ( response ) {
 				if ( 'good' === response.status ) {
 					$( '#remove-' + taxonomyImagesPlugin.tt_id ).addClass( 'hide' );
-					$( '#taxonomy_image_plugin_' + taxonomyImagesPlugin.tt_id ).attr( 'src', taxonomyImagesPlugin.img_src );
+					var imgId = 'taxonomy_image_plugin_' + taxonomyImagesPlugin.tt_id;
+					$( '#' + imgId ).replaceWith( $( taxonomyImagesPlugin.no_img ).attr( 'id', imgId ) ).remove();
 				}
 				else if ( 'bad' === response.status ) {
 					alert( response.why );

--- a/media-upload-popup.js
+++ b/media-upload-popup.js
@@ -58,8 +58,10 @@ jQuery( document ).ready( function( $ ) {
 				if ( 'good' === response.status ) {
 					button.html( TaxonomyImagesModal.removed ).fadeOut( 200, function() {
 						$( this ).hide();
-						var selector = parent.document.getElementById( 'taxonomy_image_plugin_' + ID );
-						$( selector ).attr( 'src', below.taxonomyImagesPlugin.img_src );
+						var oldImage = parent.document.getElementById( 'taxonomy_image_plugin_' + ID );
+						$( oldImage ).replaceWith( $(below.taxonomyImagesPlugin.no_img).attr( 'id', 'taxonomy_image_plugin_' + ID ) );
+						var removeBtn = parent.document.getElementById( 'remove-' + ID );
+						$( removeBtn ).addClass( 'hide' );
 						$( this ).parent().find( '.create-association' ).show();
 						$( this ).html( originalText );
 					} );
@@ -108,8 +110,11 @@ jQuery( document ).ready( function( $ ) {
 					selector = parent.document.getElementById( 'taxonomy-image-control-' + ID );
 
 					/* Update the image on the screen below */
-					$( selector ).find( '.taxonomy-image-thumbnail img' ).each( function ( i, e ) {
-						$( e ).attr( 'src', response.attachment_thumb_src );
+					$( selector ).find( '.taxonomy-images-set-featured' ).each( function ( i, e ) {
+						$( e ).replaceWith( $( '<img />' ).attr({
+							'src' : response.attachment_thumb_src,
+							'id' : $( e ).attr( 'id' )
+						}) );
 					} );
 
 					/* Show delete control on the screen below */

--- a/media-upload-popup.js
+++ b/media-upload-popup.js
@@ -58,10 +58,19 @@ jQuery( document ).ready( function( $ ) {
 				if ( 'good' === response.status ) {
 					button.html( TaxonomyImagesModal.removed ).fadeOut( 200, function() {
 						$( this ).hide();
+
+						// remove the thumbnail & replace it with "set featured image"
 						var oldImage = parent.document.getElementById( 'taxonomy_image_plugin_' + ID );
-						$( oldImage ).replaceWith( $(below.taxonomyImagesPlugin.no_img).attr( 'id', 'taxonomy_image_plugin_' + ID ) );
+						$( oldImage ).replaceWith( $( below.taxonomyImagesPlugin.no_img ).attr( 'id', 'taxonomy_image_plugin_' + ID ) );
+
+						// hide the remove button that was under the thumbnail
 						var removeBtn = parent.document.getElementById( 'remove-' + ID );
 						$( removeBtn ).addClass( 'hide' );
+
+						// update the hidden image id field
+						$( parent.document.getElementById( 'taxonomy-image-control-' + ID ) ).find( '.image_id' ).val( '0' );
+
+						// show the create association button
 						$( this ).parent().find( '.create-association' ).show();
 						$( this ).html( originalText );
 					} );
@@ -107,18 +116,21 @@ jQuery( document ).ready( function( $ ) {
 						$( e ).find( '.remove-association' ).hide();
 					} );
 
-					selector = parent.document.getElementById( 'taxonomy-image-control-' + ID );
+					var $selector = $( parent.document.getElementById( 'taxonomy-image-control-' + ID ) );
 
 					/* Update the image on the screen below */
-					$( selector ).find( '.taxonomy-images-set-featured' ).each( function ( i, e ) {
+					$selector.find( '.taxonomy-images-set-featured' ).each( function ( i, e ) {
 						$( e ).replaceWith( $( '<img />' ).attr({
 							'src' : response.attachment_thumb_src,
 							'id' : $( e ).attr( 'id' )
 						}) );
 					} );
 
+					// Update the hidden image_id field
+					$selector.find( '.image_id' ).val( response.image_id );
+
 					/* Show delete control on the screen below */
-					$( selector ).find( '.remove' ).each( function ( i, e ) {
+					$selector.find( '.remove' ).each( function ( i, e ) {
 						$( e ).removeClass( 'hide' );
 					} );
 

--- a/taxonomy-images.php
+++ b/taxonomy-images.php
@@ -199,10 +199,9 @@ function taxonomy_image_plugin_get_image_src( $id ) {
 
 	/*
 	 * No image can be found.
-	 * This is most likely caused by a user deleting an attachment before deleting it's association with a taxonomy.
 	 * If we are in the administration panels:
 	 * - Delete the association.
-	 * - Return uri to default.png.
+	 * - Return false.
 	 */
 	if ( is_admin() ) {
 		$assoc = taxonomy_image_plugin_get_associations();
@@ -212,11 +211,12 @@ function taxonomy_image_plugin_get_image_src( $id ) {
 			}
 		}
 		update_option( 'taxonomy_image_plugin', $assoc );
-		return taxonomy_image_plugin_url( 'default.png' );
+		return false;
 	}
 
 	/*
 	 * No image can be found.
+	 * This is most likely caused by a user deleting an attachment before deleting it's association with a taxonomy.
 	 * Return path to blank-image.png.
 	 */
 	return taxonomy_image_plugin_url( 'blank.png' );
@@ -791,13 +791,17 @@ function taxonomy_image_plugin_control_image( $term_id, $taxonomy ) {
 	}
 
 	$img = taxonomy_image_plugin_get_image_src( $attachment_id );
+	if ( $img ) {
+		$img = '<img id="' . esc_attr( 'taxonomy_image_plugin_' . $tt_id ) . '" src="' . esc_url( $img ) . '" alt="" style="width: 75px; height: auto;" />';
+	} else {
+		$img = '<span id="' . esc_attr( 'taxonomy_image_plugin_' . $tt_id ) . '" class="taxonomy-images-set-featured">Set Featured Image</span>';
+	}
 
 	$term = get_term( $term_id, $taxonomy->name );
 
 	$o = "\n" . '<div id="' . esc_attr( 'taxonomy-image-control-' . $tt_id ) . '" class="taxonomy-image-control hide-if-no-js">';
-	$o.= "\n" . '<a class="thickbox taxonomy-image-thumbnail" href="' . esc_url( admin_url( 'media-upload.php' ) . '?type=image&tab=library&post_id=0&TB_iframe=true' ) . '" title="' . esc_attr( sprintf( __( 'Associate an image with the %1$s named &#8220;%2$s&#8221;.', 'taxonomy-images' ), $name, $term->name ) ) . '"><img id="' . esc_attr( 'taxonomy_image_plugin_' . $tt_id ) . '" src="' . esc_url( $img ) . '" alt="" /></a>';
-	$o.= "\n" . '<a class="control upload thickbox" href="' . esc_url( admin_url( 'media-upload.php' ) . '?type=image&tab=type&post_id=0&TB_iframe=true' ) . '" title="' . esc_attr( sprintf( __( 'Upload a new image for this %s.', 'taxonomy-images' ), $name ) ) . '">' . esc_html__( 'Upload.', 'taxonomy-images' ) . '</a>';
-	$o.= "\n" . '<a class="control remove' . $hide . '" href="#" id="' . esc_attr( 'remove-' . $tt_id ) . '" rel="' . esc_attr( $tt_id ) . '" title="' . esc_attr( sprintf( __( 'Remove image from this %s.', 'taxonomy-images' ), $name ) ) . '">' . esc_html__( 'Delete', 'taxonomy-images' ) . '</a>';
+	$o.= "\n" . '<a class="thickbox taxonomy-image-thumbnail" href="' . esc_url( admin_url( 'media-upload.php' ) . '?type=image&width=800&tab=library&post_id=0&TB_iframe=true' ) . '" title="' . esc_attr( sprintf( __( 'Associate an image with the %1$s named &#8220;%2$s&#8221;.', 'taxonomy-images' ), $name, $term->name ) ) . '">'.$img.'</a>';
+	$o.= "\n" . '<a class="remove ' . $hide . '" href="#" id="' . esc_attr( 'remove-' . $tt_id ) . '" rel="' . esc_attr( $tt_id ) . '" title="' . esc_attr( sprintf( __( 'Remove image from this %s.', 'taxonomy-images' ), $name ) ) . '">' . esc_html__( 'Remove Featured Image' ) . '</a>';
 	$o.= "\n" . '<input type="hidden" class="tt_id" name="' . esc_attr( 'tt_id-' . $tt_id ) . '" value="' . esc_attr( $tt_id ) . '" />';
 
 	$o.= "\n" . '<input type="hidden" class="image_id" name="' . esc_attr( 'image_id-' . $tt_id ) . '" value="' . esc_attr( $attachment_id ) . '" />';
@@ -853,7 +857,7 @@ function taxonomy_image_plugin_edit_tags_js() {
 	);
 	wp_localize_script( 'taxonomy-image-plugin-edit-tags', 'taxonomyImagesPlugin', array (
 		'nonce'    => wp_create_nonce( 'taxonomy-image-plugin-remove-association' ),
-		'img_src'  => taxonomy_image_plugin_url( 'default.png' ),
+		'no_img'  => '<span class="taxonomy-images-set-featured">Set Featured Image</span>',
 		'tt_id'    => 0,
 		'image_id' => 0,
 	) );

--- a/taxonomy-images.php
+++ b/taxonomy-images.php
@@ -173,11 +173,7 @@ function taxonomy_image_plugin_get_image_src( $id ) {
 		if ( is_file( $path ) ) {
 
 			/* Attempt to create a new downsized version of the original image. */
-			$new = image_resize( $path,
-				$detail['size'][0],
-				$detail['size'][1],
-				$detail['size'][2]
-				);
+			$new = wp_get_image_editor( $path, $detail['size'] );
 
 			/* Image creation successful. Generate and cache image metadata. Return url. */
 			if ( ! is_wp_error( $new ) ) {

--- a/taxonomy-images.php
+++ b/taxonomy-images.php
@@ -69,7 +69,7 @@ function taxonomy_image_plugin_url( $file = '' ) {
 function taxonomy_image_plugin_detail_image_size() {
 	return array(
 		'name' => 'detail',
-		'size' => array( 75, 75, true )
+		'size' => array( 150, 150, true )
 	);
 }
 

--- a/taxonomy-images.php
+++ b/taxonomy-images.php
@@ -551,7 +551,8 @@ function taxonomy_image_plugin_create_association() {
 		taxonomy_image_plugin_json_response( array(
 			'status' => 'good',
 			'why'    => esc_html__( 'Image successfully associated', 'taxonomy-images' ),
-			'attachment_thumb_src' => taxonomy_image_plugin_get_image_src( $image_id )
+			'attachment_thumb_src' => taxonomy_image_plugin_get_image_src( $image_id ),
+			'image_id' => $image_id,
 		) );
 	}
 	else {


### PR DESCRIPTION
I made some updates to make the UI work better in 3.8. Without these edits, the modal looks broken. Props to Herbert on the WordPress.org forums for figuring out that fix: http://wordpress.org/support/topic/searchbox-missing

I also made the thumbnails retina compatible.

Additionally, I changed the big question mark image to "Set Featured Image" so the UI matches the WP post featured image UI. I also removed the +/- buttons and changed that to just "Remove Featured Image"

I also fixed two bugs where if you associated an image and closed the modal, then opened the modal again, it wouldn't show the "Remove association" link for that image. Similarly if you removed an association in the modal, and then closed and reopened the modal, it wouldn't show the "Associate.." button.

If you want me to break this up into smaller pull requests, let me know. :)
