### PR TITLE
Fixed minor issue with taxonomy-images-get-terms

### DIFF
--- a/public-filters.php
+++ b/public-filters.php
@@ -89,7 +89,7 @@ function taxonomy_images_plugin_get_terms( $default, $args = array() ) {
 	}
 
 	$assoc = taxonomy_image_plugin_get_associations();
-	if ( empty( $assoc ) ) {
+	if ( ! empty( $args['having_images'] ) && empty( $assoc ) ) {
 		return array();
 	}
 


### PR DESCRIPTION
Fixed issue where, if no terms have images (i.e. taxonomy_image_plugin_get_associations() returns an empty array) but 'having_images' is false, no terms would be returned.

A minor fringe issue for sure but worthy of a quick fix!
