### PR TITLE
 use underscores instead of dashes in filter names

### DIFF
--- a/code-snippets.php
+++ b/code-snippets.php
@@ -12,7 +12,7 @@ exit;
  * Append the term images to content + excerpt.
  */
 function mytheme_append_the_term_images( $content ) {
-	return $content . apply_filters( 'taxonomy-images-list-the-terms', '', array(
+	return $content . apply_filters( 'taxonomy_images_list_the_terms', '', array(
 		'image_size' => 'detail',
 		) );
 }
@@ -34,38 +34,38 @@ add_filter( 'the_excerpt', 'mytheme_append_the_term_images' );
 
 
 /* Default */
-$img = apply_filters( 'taxonomy-images-queried-term-image', 'PLEASE INSTALL PLUGIN' );
-print '<h2>taxonomy-images-queried-term-image</h2>';
+$img = apply_filters( 'taxonomy_images_queried_term_image', 'PLEASE INSTALL PLUGIN' );
+print '<h2>taxonomy_images_queried_term_image</h2>';
 print '<pre>' . htmlentities( $img ) . '</pre>';
 
 
 /* Inside a yellow box */
-$img = apply_filters( 'taxonomy-images-queried-term-image', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image', 'PLEASE INSTALL PLUGIN', array(
 	'before' => '<div style="padding:20px;background-color:yellow;">',
 	'after'  => '</div>',
 	) );
-print '<h2>taxonomy-images-queried-term-image - custom wrapper element.</h2>';
+print '<h2>taxonomy_images_queried_term_image - custom wrapper element.</h2>';
 print '<pre>' . htmlentities( $img ) . '</pre>';
 
 
 /* Medium Size */
-$img = apply_filters( 'taxonomy-images-queried-term-image', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image', 'PLEASE INSTALL PLUGIN', array(
 	'image_size' => 'medium',
 	) );
-print '<h2>taxonomy-images-queried-term-image - medium image size</h2>';
+print '<h2>taxonomy_images_queried_term_image - medium image size</h2>';
 print '<pre>' . htmlentities( $img ) . '</pre>';
 
 
 /* Unrecognized size */
-$img = apply_filters( 'taxonomy-images-queried-term-image', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image', 'PLEASE INSTALL PLUGIN', array(
 	'image_size' => 'this-is-probably-not-a-real-image-size',
 	) );
-print '<h2>taxonomy-images-queried-term-image - unknown image size</h2>';
+print '<h2>taxonomy_images_queried_term_image - unknown image size</h2>';
 print '<pre>' . htmlentities( $img ) . '</pre>';
 
 
 /* Custom attributes. */
-$img = apply_filters( 'taxonomy-images-queried-term-image', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image', 'PLEASE INSTALL PLUGIN', array(
 	'attr' => array(
 		'alt'   => 'Custom alternative text',
 		'class' => 'my-class-list bunnies turtles',
@@ -73,7 +73,7 @@ $img = apply_filters( 'taxonomy-images-queried-term-image', 'PLEASE INSTALL PLUG
 		'title' => 'Custom Title',
 		),
 	) );
-print '<h2>taxonomy-images-queried-term-image - custom attributes</h2>';
+print '<h2>taxonomy_images_queried_term_image - custom attributes</h2>';
 print '<pre>' . htmlentities( $img ) . '</pre>';
 
 
@@ -88,9 +88,9 @@ print '<pre>' . htmlentities( $img ) . '</pre>';
  * In the event that the Taxonomy Images plugin is not installed
  * apply_filters() will return it's second parameter.
  */
-$img = apply_filters( 'taxonomy-images-queried-term-image-id', 'PLEASE INSTALL PLUGIN' );
+$img = apply_filters( 'taxonomy_images_queried_term_image_id', 'PLEASE INSTALL PLUGIN' );
 
-print '<h2>taxonomy-images-queried-term-image-id</h2>';
+print '<h2>taxonomy_images_queried_term_image_id</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';
 
 
@@ -106,9 +106,9 @@ print '<pre>'; var_dump( $img ); print '</pre>';
  * In the event that the Taxonomy Images plugin is not installed
  * apply_filters() will return it's second parameter.
  */
-$img = apply_filters( 'taxonomy-images-queried-term-image-object', 'PLEASE INSTALL PLUGIN' );
+$img = apply_filters( 'taxonomy_images_queried_term_image_object', 'PLEASE INSTALL PLUGIN' );
 
-print '<h2>taxonomy-images-queried-term-image-object</h2>';
+print '<h2>taxonomy_images_queried_term_image_object</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';
 
 
@@ -127,24 +127,24 @@ print '<pre>'; var_dump( $img ); print '</pre>';
 
 
 /* Default */
-$img = apply_filters( 'taxonomy-images-queried-term-image-url', 'PLEASE INSTALL PLUGIN' );
-print '<h2>taxonomy-images-queried-term-image-url - Default</h2>';
+$img = apply_filters( 'taxonomy_images_queried_term_image_url', 'PLEASE INSTALL PLUGIN' );
+print '<h2>taxonomy_images_queried_term_image_url - Default</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';
 
 
 /* Medium Size */
-$img = apply_filters( 'taxonomy-images-queried-term-image-url', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image_url', 'PLEASE INSTALL PLUGIN', array(
 	'image_size' => 'medium'
 	) );
-print '<h2>taxonomy-images-queried-term-image-url - Medium</h2>';
+print '<h2>taxonomy_images_queried_term_image_url - Medium</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';
 
 
 /* Unregistered Size */
-$img = apply_filters( 'taxonomy-images-queried-term-image-url', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image_url', 'PLEASE INSTALL PLUGIN', array(
 	'image_size' => 'this-is-not-real-size-probably-I-hope'
 	) );
-print '<h2>taxonomy-images-queried-term-image-url - Unregistered</h2>';
+print '<h2>taxonomy_images_queried_term_image_url - Unregistered</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';
 
 
@@ -163,22 +163,22 @@ print '<pre>'; var_dump( $img ); print '</pre>';
 
 
 /* Default */
-$img = apply_filters( 'taxonomy-images-queried-term-image-data', 'PLEASE INSTALL PLUGIN' );
-print '<h2>taxonomy-images-queried-term-image-data - Default</h2>';
+$img = apply_filters( 'taxonomy_images_queried_term_image_data', 'PLEASE INSTALL PLUGIN' );
+print '<h2>taxonomy_images_queried_term_image_data - Default</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';
 
 
 /* Medium Size */
-$img = apply_filters( 'taxonomy-images-queried-term-image-data', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image_data', 'PLEASE INSTALL PLUGIN', array(
 	'image_size' => 'medium'
 	) );
-print '<h2>taxonomy-images-queried-term-image-data - Medium</h2>';
+print '<h2>taxonomy_images_queried_term_image_data - Medium</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';
 
 
 /* Unregistered Size */
-$img = apply_filters( 'taxonomy-images-queried-term-image-data', 'PLEASE INSTALL PLUGIN', array(
+$img = apply_filters( 'taxonomy_images_queried_term_image_data', 'PLEASE INSTALL PLUGIN', array(
 	'image_size' => 'this-is-not-real-size-probably-I-hope'
 	) );
-print '<h2>taxonomy-images-queried-term-image-data - Unregistered</h2>';
+print '<h2>taxonomy_images_queried_term_image_data - Unregistered</h2>';
 print '<pre>'; var_dump( $img ); print '</pre>';

--- a/public-filters.php
+++ b/public-filters.php
@@ -18,15 +18,15 @@
  */
 
 
-add_filter( 'taxonomy-images-get-terms',      'taxonomy_images_plugin_get_terms', 10, 2 );
-add_filter( 'taxonomy-images-get-the-terms',  'taxonomy_images_plugin_get_the_terms', 10, 2 );
-add_filter( 'taxonomy-images-list-the-terms', 'taxonomy_images_plugin_list_the_terms', 10, 2 );
+add_filter( 'taxonomy_images_get_terms',      'taxonomy_images_plugin_get_terms', 10, 2 );
+add_filter( 'taxonomy_images_get_the_terms',  'taxonomy_images_plugin_get_the_terms', 10, 2 );
+add_filter( 'taxonomy_images_list_the_terms', 'taxonomy_images_plugin_list_the_terms', 10, 2 );
 
-add_filter( 'taxonomy-images-queried-term-image',        'taxonomy_images_plugin_get_queried_term_image', 10, 2 );
-add_filter( 'taxonomy-images-queried-term-image-data',   'taxonomy_images_plugin_get_queried_term_image_data', 10, 2 );
-add_filter( 'taxonomy-images-queried-term-image-id',     'taxonomy_images_plugin_get_queried_term_image_id' );
-add_filter( 'taxonomy-images-queried-term-image-object', 'taxonomy_images_plugin_get_queried_term_image_object' );
-add_filter( 'taxonomy-images-queried-term-image-url',    'taxonomy_images_plugin_get_queried_term_image_url', 10, 2 );
+add_filter( 'taxonomy_images_queried_term_image',        'taxonomy_images_plugin_get_queried_term_image', 10, 2 );
+add_filter( 'taxonomy_images_queried_term_image_data',   'taxonomy_images_plugin_get_queried_term_image_data', 10, 2 );
+add_filter( 'taxonomy_images_queried_term_image_id',     'taxonomy_images_plugin_get_queried_term_image_id' );
+add_filter( 'taxonomy_images_queried_term_image_object', 'taxonomy_images_plugin_get_queried_term_image_object' );
+add_filter( 'taxonomy_images_queried_term_image_url',    'taxonomy_images_plugin_get_queried_term_image_url', 10, 2 );
 
 
 /**
@@ -63,11 +63,11 @@ add_filter( 'taxonomy-images-queried-term-image-url',    'taxonomy_images_plugin
  * @param     array     Named arguments. Please see above for explantion.
  * @return    array     List of term objects.
  *
- * @access    private   Use the 'taxonomy-images-get-terms' filter.
+ * @access    private   Use the 'taxonomy_images_get_terms' filter.
  * @since     0.7
  */
 function taxonomy_images_plugin_get_terms( $default, $args = array() ) {
-	$filter = 'taxonomy-images-get-terms';
+	$filter = 'taxonomy_images_get_terms';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
@@ -155,11 +155,11 @@ function taxonomy_images_plugin_get_terms( $default, $args = array() ) {
  * @param     array     Named arguments. Please see above for explantion.
  * @return    array     List of term objects. Empty array if none were found.
  *
- * @access    private   Use the 'taxonomy-images-get-the-terms' filter.
+ * @access    private   Use the 'taxonomy_images_get_the_terms' filter.
  * @since     0.7
  */
 function taxonomy_images_plugin_get_the_terms( $default, $args = array() ) {
-	$filter = 'taxonomy-images-get-the-terms';
+	$filter = 'taxonomy_images_get_the_terms';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
@@ -245,11 +245,11 @@ function taxonomy_images_plugin_get_the_terms( $default, $args = array() ) {
  * @param     array     Named arguments. Please see above for explantion.
  * @return    string    HTML markup.
  *
- * @access    private   Use the 'taxonomy-images-list-the-terms' filter.
+ * @access    private   Use the 'taxonomy_images_list_the_terms' filter.
  * @since     0.7
  */
 function taxonomy_images_plugin_list_the_terms( $default, $args = array() ) {
-	$filter = 'taxonomy-images-list-the-terms';
+	$filter = 'taxonomy_images_list_the_terms';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
@@ -270,7 +270,7 @@ function taxonomy_images_plugin_list_the_terms( $default, $args = array() ) {
 		return '';
 	}
 
-	$terms = apply_filters( 'taxonomy-images-get-the-terms', '', $args );
+	$terms = apply_filters( 'taxonomy_images_get_the_terms', '', $args );
 
 	if ( empty( $terms ) ) {
 		return '';
@@ -319,11 +319,11 @@ function taxonomy_images_plugin_list_the_terms( $default, $args = array() ) {
  * @param     array     Named array of arguments.
  * @return    string    HTML markup for the associated image.
  *
- * @access    private   Use the 'taxonomy-images-queried-term-image' filter.
+ * @access    private   Use the 'taxonomy_images_queried_term_image' filter.
  * @since     0.7
  */
 function taxonomy_images_plugin_get_queried_term_image( $default, $args = array() ) {
-	$filter = 'taxonomy-images-queried-term-image';
+	$filter = 'taxonomy_images_queried_term_image';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
@@ -335,7 +335,7 @@ function taxonomy_images_plugin_get_queried_term_image( $default, $args = array(
 		'image_size' => 'thumbnail',
 		) );
 
-	$ID = apply_filters( 'taxonomy-images-queried-term-image-id', 0 );
+	$ID = apply_filters( 'taxonomy_images_queried_term_image_id', 0 );
 
 	if ( empty( $ID ) ) {
 		return '';
@@ -364,16 +364,16 @@ function taxonomy_images_plugin_get_queried_term_image( $default, $args = array(
  *
  * This function should never be called directly in any file
  * however it may be access in any template file via the
- * 'taxonomy-images-queried-term-image-id' filter.
+ * 'taxonomy_images_queried_term_image_id' filter.
  *
  * @param     mixed     Default value for apply_filters() to return. Unused.
  * @return    int       Image attachment's ID.
  *
- * @access    private   Use the 'taxonomy-images-queried-term-image-id' filter.
+ * @access    private   Use the 'taxonomy_images_queried_term_image_id' filter.
  * @since     0.7
  */
 function taxonomy_images_plugin_get_queried_term_image_id( $default ) {
-	$filter = 'taxonomy-images-queried-term-image-id';
+	$filter = 'taxonomy_images_queried_term_image_id';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
@@ -419,21 +419,21 @@ function taxonomy_images_plugin_get_queried_term_image_id( $default ) {
  *
  * This function should never be called directly in any file
  * however it may be access in any template file via the
- * 'taxonomy-images-queried-term-image' filter.
+ * 'taxonomy_images_queried_term_image' filter.
  *
  * @param     mixed          Default value for apply_filters() to return. Unused.
  * @return    stdClass       WordPress Post object.
  *
- * @access    private        Use the 'taxonomy-images-queried-term-image-object' filter.
+ * @access    private        Use the 'taxonomy_images_queried_term_image_object' filter.
  * @since     0.7
  */
 function taxonomy_images_plugin_get_queried_term_image_object( $default ) {
-	$filter = 'taxonomy-images-queried-term-image-object';
+	$filter = 'taxonomy_images_queried_term_image_object';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
 
-	$ID = apply_filters( 'taxonomy-images-queried-term-image-id', 0 );
+	$ID = apply_filters( 'taxonomy_images_queried_term_image_id', 0 );
 
 	$image = new stdClass;
 	if ( ! empty( $ID ) ) {
@@ -464,11 +464,11 @@ function taxonomy_images_plugin_get_queried_term_image_object( $default ) {
  * @param     array          Named Arguments.
  * @return    string         Image URL.
  *
- * @access    private        Use the 'taxonomy-images-queried-term-image-url' filter.
+ * @access    private        Use the 'taxonomy_images_queried_term_image_url' filter.
  * @since     0.7
  */
 function taxonomy_images_plugin_get_queried_term_image_url( $default, $args = array() ) {
-	$filter = 'taxonomy-images-queried-term-image-url';
+	$filter = 'taxonomy_images_queried_term_image_url';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
@@ -477,7 +477,7 @@ function taxonomy_images_plugin_get_queried_term_image_url( $default, $args = ar
 		'image_size' => 'thumbnail',
 		) );
 
-	$data = apply_filters( 'taxonomy-images-queried-term-image-data', array(), $args );
+	$data = apply_filters( 'taxonomy_images_queried_term_image_data', array(), $args );
 
 	$url = '';
 	if ( isset( $data['url'] ) ) {
@@ -509,12 +509,12 @@ function taxonomy_images_plugin_get_queried_term_image_url( $default, $args = ar
  * @param     array          Named Arguments.
  * @return    array          Image data: url, width and height.
  *
- * @access    private        Use the 'taxonomy-images-queried-term-image-data' filter.
+ * @access    private        Use the 'taxonomy_images_queried_term_image_data' filter.
  * @since     0.7
  * @alter     0.7.2
  */
 function taxonomy_images_plugin_get_queried_term_image_data( $default, $args = array() ) {
-	$filter = 'taxonomy-images-queried-term-image-data';
+	$filter = 'taxonomy_images_queried_term_image_data';
 	if ( $filter !== current_filter() ) {
 		taxonomy_image_plugin_please_use_filter( __FUNCTION__, $filter );
 	}
@@ -523,7 +523,7 @@ function taxonomy_images_plugin_get_queried_term_image_data( $default, $args = a
 		'image_size' => 'thumbnail',
 		) );
 
-	$ID = apply_filters( 'taxonomy-images-queried-term-image-id', 0 );
+	$ID = apply_filters( 'taxonomy_images_queried_term_image_id', 0 );
 
 	if ( empty( $ID ) ) {
 		return array();

--- a/taxonomy-images.php
+++ b/taxonomy-images.php
@@ -910,13 +910,13 @@ add_action( 'admin_print_styles-edit-tags.php', 'taxonomy_image_plugin_css_thick
  * insert the following code into your theme's functions.php
  * file:
  *
- * add_filter( 'taxonomy-images-disable-public-css', '__return_true' );
+ * add_filter( 'taxonomy_images_disable_public_css', '__return_true' );
  *
  * @since     0.7
  * @access    private
  */
 function taxonomy_image_plugin_css_public() {
-	if ( apply_filters( 'taxonomy-images-disable-public-css', false ) )
+	if ( apply_filters( 'taxonomy_images_disable_public_css', false ) )
 		return;
 
 	wp_enqueue_style(


### PR DESCRIPTION
Fixed `WordPress.NamingConventions.ValidHookName.UseUnderscores` errors.